### PR TITLE
[DP-686] Resolve an issue on Local Email Service

### DIFF
--- a/database/migrations/2025_05_08_000000_add_configuration_fields_to_local_email_config_table.php
+++ b/database/migrations/2025_05_08_000000_add_configuration_fields_to_local_email_config_table.php
@@ -1,0 +1,37 @@
+<?php
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class AddConfigurationFieldsToLocalEmailConfigTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        if (Schema::hasTable('local_email_config') && !Schema::hasColumn('local_email_config', 'command')) {
+            Schema::table('local_email_config', function (Blueprint $t) {
+                $t->string('command')->nullable()->default('/usr/sbin/sendmail -bs');
+            });
+        }
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        if (Schema::hasTable('local_email_config') && Schema::hasColumn('local_email_config', 'command')) {
+            Schema::table('local_email_config', function (Blueprint $t) {
+                $t->dropColumn([
+                    'command'
+                ]);
+            });
+        }
+    }
+}

--- a/src/Models/LocalEmailConfig.php
+++ b/src/Models/LocalEmailConfig.php
@@ -2,14 +2,18 @@
 
 namespace DreamFactory\Core\Email\Models;
 
+use DreamFactory\Core\Email\Components\SupportsEmailParameters;
 use DreamFactory\Core\Models\BaseServiceConfigModel;
 
 class LocalEmailConfig extends BaseServiceConfigModel
 {
+    use SupportsEmailParameters;
+
     protected $table = 'local_email_config';
 
     protected $fillable = [
         'service_id',
+        'command',
         'from_name',
         'from_email',
         'reply_to_name',
@@ -22,4 +26,19 @@ class LocalEmailConfig extends BaseServiceConfigModel
 
     // Add this property to define which fields should be treated as dates
     protected $dates = [];
+
+    /**
+     * @param array $schema
+     */
+    protected static function prepareConfigSchemaField(array &$schema)
+    {
+        parent::prepareConfigSchemaField($schema);
+
+        switch ($schema['name']) {
+            case 'command':
+                $schema['label'] = 'Local Command';
+                $schema['description'] = 'Local command to be executed to send mail.';
+                break;
+        }
+    }
 }


### PR DESCRIPTION
The local email service is currently showing a paywall because it does not include any parameters in the configSchema. Based on the screenshot of how it looked and functioned previously:
![image](https://github.com/user-attachments/assets/aed225fc-1abd-4ecf-ad8c-4e144970010c)
We implemented the following solutions:
1. We reintroduced the use SupportsEmailParameters component in LocalEmailConfig, as it appears that these parameters were included in the past.
2. We implemented a migration to add a “command” column to the local_email_config table, which seems to have been used in the previous implementation.
3. We tested these changes using the default command value of "/usr/sbin/sendmail -bs" to ensure that the email functionality is working properly and that emails are being sent successfully.