### PR TITLE
Upgrade to Laravel 13.7 / PHP 8.3 / PHPUnit 11

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,11 @@
 > **Note:** This repository contains the email code of the DreamFactory platform. 
 If you want the full DreamFactory platform, visit the main [DreamFactory repository](https://github.com/dreamfactorysoftware/dreamfactory).
 
+
+## Overview
+
+DreamFactory is a secure, self-hosted enterprise data access platform that provides governed API access to any data source, connecting enterprise applications and on-prem LLMs with role-based access and identity passthrough.
+
 ## Documentation
 
 Documentation for the platform can be found on the [DreamFactory wiki](http://wiki.dreamfactory.com).

--- a/composer.json
+++ b/composer.json
@@ -31,14 +31,20 @@
   "minimum-stability": "dev",
   "prefer-stable":     true,
   "require":     {
+    "php": "^8.3",
+    "laravel/helpers": "^1.8",
     "dreamfactory/df-core": "~1.0.4",
     "guzzlehttp/guzzle": "~7.2",
     "symfony/mailgun-mailer": "^7.2",
     "symfony/mailer": "^7.2",
-    "symfony/http-client": "^6.4"
+    "symfony/http-client": "^7.2"
   },
   "require-dev": {
-    "phpunit/phpunit": "@stable"
+    "laravel/framework": "^13.7",
+    "mockery/mockery": "^1.6",
+    "nunomaduro/collision": "^8.6",
+    "phpunit/phpunit": "^11.5.3",
+    "orchestra/testbench": "^11.0"
   },
   "autoload":    {
     "psr-4": {

--- a/src/Services/Mandrill.php
+++ b/src/Services/Mandrill.php
@@ -3,10 +3,14 @@
 namespace DreamFactory\Core\Email\Services;
 
 use DreamFactory\Core\Exceptions\InternalServerErrorException;
-use GuzzleHttp\Client;
-use Illuminate\Mail\Transport\MandrillTransport;
 use \Illuminate\Support\Arr;
 
+/**
+ * Mandrill transport support was removed upstream by Laravel/Symfony and the
+ * Mandrill API itself is no longer publicly available for new customers.
+ * The class is retained for backward compatibility with stored service-type
+ * registrations, but instantiation now throws.
+ */
 class Mandrill extends BaseService
 {
     protected function setTransport(array $config)
@@ -16,17 +20,15 @@ class Mandrill extends BaseService
     }
 
     /**
-     * @param $key
+     * @param string|null $key
      *
-     * @return \Illuminate\Mail\Transport\MandrillTransport
-     * @throws \DreamFactory\Core\Exceptions\InternalServerErrorException
+     * @throws InternalServerErrorException
+     * @return never
      */
     public static function getTransport($key)
     {
-        if (empty($key)) {
-            throw new InternalServerErrorException('Missing key for Mandrill service.');
-        }
-
-        return new MandrillTransport(new Client(), $key);
+        throw new InternalServerErrorException(
+            'Mandrill transport is no longer supported. Please switch to a supported email service (SMTP, Mailgun, etc.).'
+        );
     }
 }

--- a/src/Services/SparkPost.php
+++ b/src/Services/SparkPost.php
@@ -3,10 +3,15 @@
 namespace DreamFactory\Core\Email\Services;
 
 use DreamFactory\Core\Exceptions\InternalServerErrorException;
-use GuzzleHttp\Client;
-use Illuminate\Mail\Transport\SparkPostTransport;
 use \Illuminate\Support\Arr;
 
+/**
+ * SparkPost transport support was removed when Laravel migrated from
+ * SwiftMailer to Symfony Mailer in Laravel 7+. There is no first-party
+ * Symfony bridge for SparkPost. The class is retained for backward
+ * compatibility with stored service-type registrations, but instantiation
+ * now throws.
+ */
 class SparkPost extends BaseService
 {
     protected function setTransport(array $config)
@@ -17,18 +22,16 @@ class SparkPost extends BaseService
     }
 
     /**
-     * @param $key
-     * @param $options
+     * @param string|null $key
+     * @param array       $options
      *
-     * @return \Illuminate\Mail\Transport\SparkPostTransport
-     * @throws \DreamFactory\Core\Exceptions\InternalServerErrorException
+     * @throws InternalServerErrorException
+     * @return never
      */
     public static function getTransport($key, $options = [])
     {
-        if (empty($key)) {
-            throw new InternalServerErrorException('Missing key for SparkPost service.');
-        }
-
-        return new SparkPostTransport(new Client(), $key, $options);
+        throw new InternalServerErrorException(
+            'SparkPost transport is no longer supported. Please switch to a supported email service (SMTP, Mailgun, etc.).'
+        );
     }
 }


### PR DESCRIPTION
## Summary

Wave 3 of the df-* Laravel 11 -> 13 upgrade campaign. Brings df-email up to L13.7 / PHP 8.3 / PHPUnit 11 / orchestra/testbench 11.

## Changes

**composer.json**
- Add `php ^8.3` and `laravel/helpers ^1.8` to `require`
- Bump `symfony/http-client` from `^6.4` to `^7.2` (aligns with the existing `^7.2` floor on `symfony/mailer` and `symfony/mailgun-mailer`)
- Replace single `phpunit/phpunit @stable` dev dep with the full L13 dev matrix: `laravel/framework ^13.7`, `mockery/mockery ^1.6`, `nunomaduro/collision ^8.6`, `phpunit/phpunit ^11.5.3`, `orchestra/testbench ^11.0`
- `dreamfactory/df-core ~1.0.4` constraint unchanged (resolves to df-core's `shift/laravel-13` head once tagged)

**src/Services/Mandrill.php and src/Services/SparkPost.php**
- Drop dead imports of `Illuminate\Mail\Transport\MandrillTransport` and `SparkPostTransport`. These classes were removed when Laravel migrated from SwiftMailer to Symfony Mailer in Laravel 7+
- There is no first-party Symfony bridge for either provider (Mandrill itself is no longer publicly available for new customers)
- Both classes are retained for backward compatibility with persisted service-type rows but now throw a clear "no longer supported" `InternalServerErrorException` if instantiated
- Neither service is registered in `ServiceProvider::register()`, so this is a no-op for active deployments

The remaining transports (Local sendmail, SMTP via `EsmtpTransport`, Mailgun via `MailgunApiTransport`) already use Symfony Mailer APIs and need no source changes.

## Test plan

- [x] `composer validate --strict` passes
- [x] Stage 1: standalone `composer install` against path-repo'd df-core / df-system / df-database all on `shift/laravel-13`, resolves cleanly to laravel/framework 13.7.0
- [x] Stage 1 smoke: 18/18 namespaced classes load; all 5 helper polyfills (`array_get`, `camel_case`, `array_except`, `snake_case`, `starts_with`) resolve; all 3 active Symfony transport classes (`Smtp\EsmtpTransport`, `SendmailTransport`, `Mailgun\MailgunApiTransport`) exist
- [x] Stage 2: full host-app (`shift-173254`) `composer install` with df-email path-symlinked -- package discovery passes, ServiceProvider correctly extends `Illuminate\Support\ServiceProvider`, custom Mailer extends `Illuminate\Mail\Mailer`
- [ ] Post-merge: tag a `~0.13.x-l13` release once core / system / database / email are all merged

## Driver-lib versions locked in

| Package | Resolved version |
|---|---|
| laravel/framework | 13.7.0 |
| laravel/helpers | 1.8.3 |
| symfony/mailer | 7.4.8 |
| symfony/mailgun-mailer | 7.4.0 |
| symfony/http-client | 7.4.9 |

## Blockers / Notes

- Tagging coordination: this PR depends on df-core's `shift/laravel-13` head being tagged as `~1.0.4`-compatible (e.g. `1.0.99` or a real `1.0.16`)
- No source changes required for the public mail API -- `Mailer::send()`, `Message::to/from/replyTo/attach...`, etc., are unchanged in L13
- The `: 'swift'` magic-string passed to `EmailUtilities::sanitizeAndValidateEmails()` is an internal output-format flag (returns `[email => name]`), not a SwiftMailer reference -- left unchanged